### PR TITLE
背景部分をクリックしたときのみモーダルを非表示にする機能の実装

### DIFF
--- a/modal-with-jquery/script.js
+++ b/modal-with-jquery/script.js
@@ -1,6 +1,14 @@
 $(function() {
   $('#modal-btn').on('click', function() {
     $('.modal').addClass('modal-container');
+    $('.modal-container').on('click', function(event) {
+      // 背景部分をクリックしたときのみモーダルを非表示にする
+      if(event.target !== event.currentTarget) {
+        return;
+      } else {
+        $('.modal').removeClass('modal-container');
+      }
+    })
   });
   $('.modal-close').on('click', function() {
     $('.modal').removeClass('modal-container');


### PR DESCRIPTION
jQueryのイベントの引数から取れる`target`と`currentTarget`はJSと同じものなのかな？
特に難しいところはなくすんなりいけた。